### PR TITLE
How_to_flash.md: fix suggested command

### DIFF
--- a/How_to_flash.md
+++ b/How_to_flash.md
@@ -94,7 +94,7 @@ qmk flash -kb <keyboard> -km <keymap>
 so likely you will use
 
 ```bash
-qmk compile -kb desnarler_v1 -km default_pure_linux
+qmk flash -kb desnarler_v1 -km default
 ```
 
 #### Troubleshooting Flashing


### PR DESCRIPTION
The correct "likely" command to flash is "flash" (not compile) and does not have the pure linux suffix.